### PR TITLE
Set default to text (as per docs)

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReadmeFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeFromPod.pm
@@ -78,8 +78,8 @@ sub setup_installer {
             'html'     => 'html',
             'htm'      => 'html',
             'rtf'      => 'rtf',
-            'txt'      => 'txt',
-            ''         => 'pod',
+            'txt'      => 'text',
+            ''         => 'text',
             'pod'      => 'pod'
         );
         foreach my $e (keys %ext) {


### PR DESCRIPTION
The documentation says that the default format is "text", but it was "pod".
Also, forcing the format to "txt" was not working.

I figured out because I made a new release of a module some days ago and it regenerated my README in pod format.