### PR TITLE
Auto-detect pod file if present

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReadmeFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeFromPod.pm
@@ -17,7 +17,10 @@ has filename => (
 
 sub _build_filename {
     my $self = shift;
-    $self->zilla->main_module->name;
+    # copied from Dist::Zilla::Plugin::ReadmeAnyFromPod
+    my $pm = $self->zilla->main_module->name;
+    (my $pod = $pm) =~ s/\.pm$/\.pod/;
+    return -e $pod ? $pod : $pm;
 }
 
 has type => (


### PR DESCRIPTION
Current release of this module always extracts POD from the ".pm" file, which should not be the case when the ".pod" alternative is present. I copied this solution from Dist::Zilla::Plugin::ReadmeAnyFromPod https://github.com/gitpan/Dist-Zilla-Plugin-ReadmeAnyFromPod/blob/master/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm#L99