### PR TITLE
Use Path::Tiny API instead of Path::Class over the dzill root object

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist-Zilla-Plugin-ReadmeFromPod
 
 {{$NEXT}}
+    - Updated to use Path::Tiny API instead of Path::Class (diegok)
 
 0.34 2016-10-08 09:38:53
     - Auto-detect pod file if present (GH#6, polettix)

--- a/lib/Dist/Zilla/Plugin/ReadmeFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeFromPod.pm
@@ -86,7 +86,7 @@ sub setup_installer {
             'pod'      => 'pod'
         );
         foreach my $e (keys %ext) {
-            my $test_readme_file = $self->zilla->root->file($e ? "README.$e" : 'README');
+            my $test_readme_file = $self->zilla->root->child($e ? "README.$e" : 'README');
             if (-e "$test_readme_file") {
                 $readme_file = $test_readme_file;
                 $pod_class = $FORMATS{ $ext{$e} }->{class};


### PR DESCRIPTION
This change fix a warning about the usage of the old API when building the readme file path:

```
->file called on a Dist::Zilla::Path object; this will cease to work in Dist::Zilla v7; downstream code should be updated to use Path::Tiny API, not Path::Class at /Users/diegok/perl5/perlbrew/perls/perl-5.24.0/lib/site_perl/5.24.0/Dist/Zilla/Plugin/ReadmeFromPod.pm line 90.
```
