### PR TITLE
fix syntax of version check for Pod::Readme

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReadmeFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeFromPod.pm
@@ -6,7 +6,7 @@ with 'Dist::Zilla::Role::InstallTool' => { -version => 5 }; # after PodWeaver
 with 'Dist::Zilla::Role::FilePruner';
 
 use IO::String;
-use Pod::Readme 'v1.2.0';
+use Pod::Readme v1.2.0;
 use Path::Tiny 0.004;
 
 has filename => (


### PR DESCRIPTION
A string on a use line will be interpreted as an import argument, not a version to check. In the case of Pod::Readme, this means that the version will be entirely ignored. Future versions of perl are intending to throw errors for arguments passed to an undefined import method.